### PR TITLE
Change Codemirror mode to "clike"

### DIFF
--- a/clingkernel.py
+++ b/clingkernel.py
@@ -83,7 +83,7 @@ class ClingKernel(Kernel):
         return 'cling-%s' % self.language_version
         return self._banner
 
-    language_info = {'name': 'c++',
+    language_info = {'name': 'clike',
                      'codemirror_mode': 'c++',
                      'mimetype': ' text/x-c++src',
                      'file_extension': '.c++'}

--- a/clingkernel.py
+++ b/clingkernel.py
@@ -83,8 +83,8 @@ class ClingKernel(Kernel):
         return 'cling-%s' % self.language_version
         return self._banner
 
-    language_info = {'name': 'clike',
-                     'codemirror_mode': 'c++',
+    language_info = {'name': 'c++',
+                     'codemirror_mode': 'clike',
                      'mimetype': ' text/x-c++src',
                      'file_extension': '.c++'}
     


### PR DESCRIPTION
Having the mode set to "c++" did not provide the proper code highlighting, but
"clike" does.  This was suggested to me by @Carreau.
